### PR TITLE
Return a Buffer rather than a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ var es = require('event-stream'),
 
 module.exports = function(opt){
   function modifyFile(file, cb){
-    file.contents = beautify.beautifyJs(String(file.contents), opt);
+    file.contents = new Buffer(beautify.beautifyJs(String(file.contents), opt));
     cb(null, file);
   }
 


### PR DESCRIPTION
This was throwing the following error.

```
[gulp] Using file /REDACTED/Gulpfile.js
[gulp] Working directory changed to /REDACTED
[gulp] Running 'js'...
[gulp] Finished 'js' in 4.16 ms

/REDACTED/node_modules/gulp-uglify/node_modules/event-stream/node_modules/map-stream/index.js:95
        throw err
              ^
Error: File.contents can only be a Buffer, a Stream, or null.
    at File.Object.defineProperty.set (/REDACTED/node_modules/gulp-browserify/node_modules/gulp-util/node_modules/vinyl/index.js:92:13)
    at modifyFile (/REDACTED/node_modules/gulp-beautify/index.js:6:19)
    at wrappedMapper (/REDACTED/node_modules/gulp-beautify/node_modules/event-stream/node_modules/map-stream/index.js:76:19)
    at Stream.stream.write (/REDACTED/node_modules/gulp-beautify/node_modules/event-stream/node_modules/map-stream/index.js:88:21)
    at Stream.ondata (stream.js:51:26)
    at Stream.EventEmitter.emit (events.js:95:17)
    at queueData (/REDACTED/node_modules/gulp-uglify/node_modules/event-stream/node_modules/map-stream/index.js:38:21)
    at next (/REDACTED/node_modules/gulp-uglify/node_modules/event-stream/node_modules/map-stream/index.js:68:5)
    at /REDACTED/node_modules/gulp-uglify/node_modules/event-stream/node_modules/map-stream/index.js:77:7
    at /REDACTED/node_modules/gulp-uglify/index.js:16:3
```
